### PR TITLE
Speed up and stabilize form updates in the popup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "Formik State Inspector",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Inspect Formik form state in React applications with real-time updates. View values, errors, and touched fields instantly.",
 	"author": "Sean Flanagan",
 	"homepage_url": "https://github.com/FlanaganSe/formik-state-inspector",

--- a/src/content.js
+++ b/src/content.js
@@ -34,7 +34,9 @@
     if (event.data.type === "forms-update") {
       const forms = event.data?.forms;
       currentForms = Array.isArray(forms) ? forms : [];
+      // Update badge and forward updates to extension contexts (e.g., popup)
       safeSendMessage({ type: "update-badge", count: currentForms.length });
+      safeSendMessage({ type: "forms-update", forms: currentForms });
     }
   });
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -412,3 +412,17 @@ if (clearSearchBtn && searchInput) {
 }
 
 document.addEventListener("DOMContentLoaded", getForms);
+
+// Live updates while popup is open
+if (chrome?.runtime?.onMessage) {
+  chrome.runtime.onMessage.addListener((message, sender) => {
+    if (!message?.type || !sender?.tab?.id) return;
+    if (!currentTab?.id || sender.tab.id !== currentTab.id) return;
+
+    if (message.type === "forms-update") {
+      const forms = Array.isArray(message.forms) ? message.forms : [];
+      // Force render to reflect same-field changes
+      renderForms(forms, { force: true });
+    }
+  });
+}


### PR DESCRIPTION
Bump manifest to v1.0.2.

- Forward `forms-update` from content to extension; update badge and popup.
- Popup listens and re-renders immediately (force render) on updates.
- Remove coarse hashing in injector; emit on every commit (debounced) to avoid m
issed same-field changes.