### PR TITLE
feat: remove redundant top elements for rendering form count & query results

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -95,30 +95,6 @@ body {
   font-weight: 500;
 }
 
-.status {
-  padding: 10px 16px;
-  background: #fff;
-  border-bottom: 1px solid #e5e7eb;
-  font-size: 13px;
-  color: #6b7280;
-}
-
-.status.active {
-  color: #059669;
-}
-
-.status.error {
-  color: #dc2626;
-}
-
-.status.loading {
-  color: #2563eb;
-}
-
-.status.inactive {
-  color: #9ca3af;
-}
-
 .empty-state {
   display: flex;
   flex-direction: column;
@@ -186,12 +162,6 @@ body {
 .form-stats {
   font-size: 12px;
   color: #6b7280;
-}
-
-.form-flags {
-  margin-top: 8px;
-  font-size: 12px;
-  color: #2563eb;
 }
 
 .form-section {

--- a/src/popup.html
+++ b/src/popup.html
@@ -16,7 +16,6 @@
         <button id="clear" title="Clear search" aria-label="Clear search">✕</button>
       </div>
     </header>
-    <div id="status" class="status" role="status" aria-live="polite">Scanning...</div>
     <div id="empty" class="empty-state" role="status">
       <div class="empty-icon" aria-hidden="true">📝</div>
       <h3>No Formik forms found</h3>


### PR DESCRIPTION
Changes:
- Remove top element that listed count of forms. 
- Remove element that listed count of forms that contain modified information when filtered
- Move the 'modified' text to be in line with other form information. 

Reason:
- Information was redundant and taking up valuable space in the popup.